### PR TITLE
Fix some edge cases in computing critical paths

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/utils/graph.js
+++ b/lighthouse-plugin-ad-speed-insights/utils/graph.js
@@ -213,11 +213,14 @@ function buildNetworkSummary(networkRecords, traceEvents) {
  */
 function getAdCriticalGraph(networkRecords, traceEvents) {
   const sinkRequest = networkRecords.find(isGptAdRequest);
+  const criticalRequests = new Set();
+  if (!sinkRequest) {
+    return criticalRequests;
+  }
   const adRequests = networkRecords
       .filter((r) => isGptAdRequest(r) || !!getHeaderBidder(r.url))
       .filter((r) => r.endTime <= sinkRequest.endTime);
   const summary = buildNetworkSummary(networkRecords, traceEvents);
-  const criticalRequests = new Set();
   for (const req of adRequests) {
     getCriticalGraph(summary, req, criticalRequests);
   }

--- a/lighthouse-plugin-ad-speed-insights/utils/graph.js
+++ b/lighthouse-plugin-ad-speed-insights/utils/graph.js
@@ -230,7 +230,9 @@ function getAdCriticalGraph(networkRecords, traceEvents) {
   for (const req of [firstAdRequest, ...bidRequests]) {
     getCriticalGraph(summary, req, criticalRequests);
   }
-  return criticalRequests;
+  const result = new Set(Array.from(criticalRequests).filter(
+    (r) => r.endTime < firstAdRequest.startTime));
+  return result;
 }
 
 module.exports = {getTransitiveClosure, getCriticalGraph, getAdCriticalGraph};

--- a/lighthouse-plugin-ad-speed-insights/utils/graph.js
+++ b/lighthouse-plugin-ad-speed-insights/utils/graph.js
@@ -206,22 +206,28 @@ function buildNetworkSummary(networkRecords, traceEvents) {
 }
 
 /**
- * Returns all requests in the loading graph of ads.
+ * Returns all requests in the loading graph of ads. This will return the empty
+ * set if no ad requests are present.
  * @param {NetworkRequest[]} networkRecords
  * @param {TraceEvent[]} traceEvents
  * @return {Set<NetworkRequest>}
  */
 function getAdCriticalGraph(networkRecords, traceEvents) {
-  const sinkRequest = networkRecords.find(isGptAdRequest);
+  /** @type {NetworkRequest} */ let firstAdRequest;
+  for (const req of networkRecords) {
+    if (isGptAdRequest(req) &&
+        (!firstAdRequest || req.startTime < firstAdRequest.startTime)) {
+      firstAdRequest = req;
+    }
+  }
   const criticalRequests = new Set();
-  if (!sinkRequest) {
+  if (!firstAdRequest) {
     return criticalRequests;
   }
-  const adRequests = networkRecords
-      .filter((r) => isGptAdRequest(r) || !!getHeaderBidder(r.url))
-      .filter((r) => r.endTime <= sinkRequest.endTime);
+  const bidRequests = networkRecords.filter((r) =>
+    !!getHeaderBidder(r.url) && r.endTime <= firstAdRequest.startTime);
   const summary = buildNetworkSummary(networkRecords, traceEvents);
-  for (const req of adRequests) {
+  for (const req of [firstAdRequest, ...bidRequests]) {
     getCriticalGraph(summary, req, criticalRequests);
   }
   return criticalRequests;


### PR DESCRIPTION
1. Fixes an error where an exception will be thrown in computing the critical path of ad loading if the ad tag is not loaded. Now the method returns the empty set rather than throwing.

2. Fixes cases where some false positive requests show up after the main ad request