### PR TITLE
Display metrics in seconds for consistency with Lighthouse core

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/ad-request-from-page-start.js
@@ -28,8 +28,8 @@ const {
 } = AUDITS[id];
 
 // Point of diminishing returns.
-const PODR = 2000;
-const MEDIAN = 2500;
+const PODR = 2.0; // seconds
+const MEDIAN = 2.5; // seconds
 
 /**
  * Audit to determine time for first ad request relative to page start.
@@ -69,7 +69,7 @@ class AdRequestFromPageStart extends Audit {
       return auditNotApplicable(NOT_APPLICABLE.NO_ADS);
     }
 
-    const adReqTime = (adStartTime - pageStartTime) * 1000;
+    const adReqTime = (adStartTime - pageStartTime);
 
     let normalScore = Audit.computeLogNormalScore(adReqTime, PODR, MEDIAN);
 
@@ -81,8 +81,7 @@ class AdRequestFromPageStart extends Audit {
     return {
       rawValue: adReqTime,
       score: normalScore,
-      displayValue:
-        util.format(displayValue, Math.round(adReqTime).toLocaleString()),
+      displayValue: util.format(displayValue, adReqTime.toFixed(2)),
     };
   }
 }

--- a/lighthouse-plugin-ad-speed-insights/audits/ad-request-from-tag-load.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/ad-request-from-tag-load.js
@@ -28,8 +28,8 @@ const {
 } = AUDITS[id];
 
 // Point of diminishing returns.
-const PODR = 300;
-const MEDIAN = 600;
+const PODR = 0.3; // seconds
+const MEDIAN = 0.6; // seconds
 
 /**
  * Audit to determine time for first ad request relative to tag load.
@@ -69,7 +69,7 @@ class AdRequestFromTagLoad extends Audit {
       return auditNotApplicable(NOT_APPLICABLE.NO_ADS);
     }
 
-    const adReqTime = (adStartTime - tagEndTime) * 1000;
+    const adReqTime = (adStartTime - tagEndTime);
 
     let normalScore = Audit.computeLogNormalScore(adReqTime, PODR, MEDIAN);
 
@@ -81,8 +81,7 @@ class AdRequestFromTagLoad extends Audit {
     return {
       rawValue: adReqTime,
       score: normalScore,
-      displayValue:
-        util.format(displayValue, Math.round(adReqTime).toLocaleString()),
+      displayValue: util.format(displayValue, adReqTime.toFixed(2)),
     };
   }
 }

--- a/lighthouse-plugin-ad-speed-insights/audits/tag-load-time.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/tag-load-time.js
@@ -28,8 +28,8 @@ const {
 } = AUDITS[id];
 
 // Point of diminishing returns.
-const PODR = 500;
-const MEDIAN = 1000;
+const PODR = 0.5; // seconds
+const MEDIAN = 1; // seconds
 /**
  * Audit to determine time for tag to load relative to page start.
  */
@@ -65,7 +65,7 @@ class TagLoadTime extends Audit {
     if (tagEndTime < 0) {
       return auditNotApplicable(NOT_APPLICABLE.NO_TAG);
     }
-    const tagLoadTime = (tagEndTime - pageStartTime) * 1000;
+    const tagLoadTime = (tagEndTime - pageStartTime);
 
     let normalScore = Audit.computeLogNormalScore(tagLoadTime, PODR, MEDIAN);
 
@@ -77,8 +77,7 @@ class TagLoadTime extends Audit {
     return {
       rawValue: tagLoadTime,
       score: normalScore,
-      displayValue:
-        util.format(displayValue, Math.round(tagLoadTime).toLocaleString()),
+      displayValue: util.format(displayValue, tagLoadTime.toFixed(2)),
     };
   }
 }

--- a/lighthouse-plugin-ad-speed-insights/messages/en-US.json
+++ b/lighthouse-plugin-ad-speed-insights/messages/en-US.json
@@ -22,13 +22,13 @@
       "title": "Latency of first ad request (from page start)",
       "failureTitle": "Reduce latency of first ad request (from page start)",
       "description": "This metric measures the elapsed time from the start of page load until the first ad request is made. Delayed ad requests will decrease impressions and viewability, and have a negative impact on ad revenue. [Learn more](https://ad-speed-insights.appspot.com/#measurements).",
-      "displayValue": "%s ms"
+      "displayValue": "%s s"
     },
     "ad-request-from-tag-load": {
       "title": "Latency of first ad request (from tag load)",
       "failureTitle": "Reduce latency of first ad request (from tag load)",
       "description": "This metric measures the elapsed time from when the Google Publisher Tag loads until the first ad request is made. [Learn more](https://ad-speed-insights.appspot.com/#measurements).",
-      "displayValue": "%s ms"
+      "displayValue": "%s s"
     },
     "ad-top-of-viewport": {
       "title": "No ad found at the very top of the viewport",
@@ -95,7 +95,7 @@
       "title": "Tag load time",
       "failureTitle": "Reduce tag load time",
       "description": "This metric measures the time for the Google Publisher Tag's implementation script (pubads_impl.js) to load after the page loads. [Learn more](https://ad-speed-insights.appspot.com/#measurements).",
-      "displayValue": "%s ms"
+      "displayValue": "%s s"
     },
     "viewport-ad-density": {
       "title": "Ad density in initial viewport is within recommended range",

--- a/lighthouse-plugin-ad-speed-insights/plugin.js
+++ b/lighthouse-plugin-ad-speed-insights/plugin.js
@@ -36,7 +36,7 @@ module.exports = {
     {path: `${PLUGIN_PATH}/audits/script-injected-tags`},
   ],
   groups: {
-    'measurements': {
+    'metrics': {
       title: 'Metrics',
     },
     'ads-performance': {
@@ -50,9 +50,9 @@ module.exports = {
     title: 'Publisher Ads [Preview]',
     auditRefs: [
       // Measurements group.
-      {id: 'tag-load-time', weight: 1, group: 'measurements'},
-      {id: 'ad-request-from-tag-load', weight: 1, group: 'measurements'},
-      {id: 'ad-request-from-page-start', weight: 1, group: 'measurements'},
+      {id: 'tag-load-time', weight: 1, group: 'metrics'},
+      {id: 'ad-request-from-tag-load', weight: 1, group: 'metrics'},
+      {id: 'ad-request-from-page-start', weight: 1, group: 'metrics'},
       // Performance group.
       {id: 'ad-blocking-tasks', weight: 1, group: 'ads-performance'},
       {id: 'ad-request-critical-path', weight: 1, group: 'ads-performance'},

--- a/lighthouse-plugin-ad-speed-insights/test/audits/ad-request-from-page-start_test.js
+++ b/lighthouse-plugin-ad-speed-insights/test/audits/ad-request-from-page-start_test.js
@@ -48,7 +48,7 @@ describe('AdRequestFromPageStart', async () => {
             },
           },
         ],
-        expectedTime: 250,
+        expectedTime: 0.25,
       },
       {
         desc: 'should not be applicable if ad is never requested',

--- a/lighthouse-plugin-ad-speed-insights/test/audits/ad-request-from-tag-load_test.js
+++ b/lighthouse-plugin-ad-speed-insights/test/audits/ad-request-from-tag-load_test.js
@@ -48,7 +48,7 @@ describe('AdRequestFromTagLoad', async () => {
             },
           },
         ],
-        expectedTime: 250,
+        expectedTime: 0.25,
       },
       {
         desc: 'should not be applicable if tag is never loaded',

--- a/lighthouse-plugin-ad-speed-insights/test/audits/tag-load-time_test.js
+++ b/lighthouse-plugin-ad-speed-insights/test/audits/tag-load-time_test.js
@@ -36,7 +36,7 @@ describe('TagLoadTime', async () => {
           {url: 'https://example.com', statusCode: 200, startTime: .1},
           {url: TAG_URL, endTime: .25},
         ],
-        expectedLoadTime: 150,
+        expectedLoadTime: 0.15,
       },
       {
         desc: 'should not be applicable if tag is never loaded',


### PR DESCRIPTION
This PR updates top-line metrics to be displayed in seconds for consistency with core lighthouse metrics. Note that detail timestamps (e.g. tables) are still in ms as the relevant time scale is usually O(ms). This is consistent with lighthouse so there are no future plans to update remaining timestamps to seconds.