### PR TITLE
Quantify estimated uplift of static tag loading in audit failure value

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/audits/static-ad-tags.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/static-ad-tags.js
@@ -73,13 +73,12 @@ function getDetailsTable(dynamicReq) {
 function quantifyOpportunitySec(tagRequest, networkRecords) {
   // The first HTML-initiated request is the best possible load time.
   const firstResource = networkRecords.find((r) =>
-    ['parser', 'preload'].includes(r.initiatorType));
+    ['parser', 'preload'].includes(r.initiator.type) ||
+    r.resourceType == 'Script');
   if (!firstResource) {
     return 0;
   }
-  const opportunitySec = tagRequest.startTime - firstResource.startTime;
-  // Scale down the opportunity to be conservative.
-  return opportunitySec * 0.9;
+  return tagRequest.startTime - firstResource.startTime;
 }
 
 /** @inheritDoc */
@@ -120,7 +119,7 @@ class StaticAdTags extends Audit {
     const table = dynamicReq ? getDetailsTable(dynamicReq) : [];
 
     const failed = numStatic < numTags;
-    let displayValue;
+    let displayValue = '';
     if (failed) {
       const opportunitySec = quantifyOpportunitySec(tagReqs[0], networkRecords);
       if (opportunitySec > 0.1) {

--- a/lighthouse-plugin-ad-speed-insights/messages/en-US.json
+++ b/lighthouse-plugin-ad-speed-insights/messages/en-US.json
@@ -90,7 +90,7 @@
       "title": "GPT tag is loaded statically",
       "failureTitle": "Load GPT tag statically",
       "description": "Tags loaded dynamically are not visible to the browser preloader. Consider using a static tag or `<link rel=\"preload\">` so the browser may load GPT sooner. [Learn more](https://ad-speed-insights.appspot.com/#dynamic-tag).",
-      "failureDisplayValue": "Up to %s sec tag load time improvement"
+      "failureDisplayValue": "Up to %s s tag load time improvement"
     },
     "tag-load-time": {
       "title": "Tag load time",

--- a/lighthouse-plugin-ad-speed-insights/messages/en-US.json
+++ b/lighthouse-plugin-ad-speed-insights/messages/en-US.json
@@ -90,7 +90,7 @@
       "title": "GPT tag is loaded statically",
       "failureTitle": "Load GPT tag statically",
       "description": "Tags loaded dynamically are not visible to the browser preloader. Consider using a static tag or `<link rel=\"preload\">` so the browser may load GPT sooner. [Learn more](https://ad-speed-insights.appspot.com/#dynamic-tag).",
-      "failureDisplayValue": "%s sec estimated tag load speed-up"
+      "failureDisplayValue": "Up to %s sec tag load time improvement"
     },
     "tag-load-time": {
       "title": "Tag load time",

--- a/lighthouse-plugin-ad-speed-insights/messages/en-US.json
+++ b/lighthouse-plugin-ad-speed-insights/messages/en-US.json
@@ -89,7 +89,8 @@
     "static-ad-tags": {
       "title": "GPT tag is loaded statically",
       "failureTitle": "Load GPT tag statically",
-      "description": "Tags loaded dynamically are not visible to the browser preloader. Consider using a static tag or `<link rel=\"preload\">` so the browser may load GPT sooner. [Learn more](https://ad-speed-insights.appspot.com/#dynamic-tag)."
+      "description": "Tags loaded dynamically are not visible to the browser preloader. Consider using a static tag or `<link rel=\"preload\">` so the browser may load GPT sooner. [Learn more](https://ad-speed-insights.appspot.com/#dynamic-tag).",
+      "failureDisplayValue": "%s sec estimated tag load speed-up"
     },
     "tag-load-time": {
       "title": "Tag load time",


### PR DESCRIPTION
Estimates the expected uplift (w.r.t. tag load time) of loading gpt statically and displays the result in the audit's failure display title