### PR TITLE
Update messages for render blocking resources audit

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/ad-render-blocking-resources.js
@@ -15,6 +15,7 @@
 const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 // @ts-ignore
 const RenderBlockingResources = require('lighthouse/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js');
+const util = require('util');
 const {auditNotApplicable} = require('../utils/builder');
 const {AUDITS, NOT_APPLICABLE} = require('../messages/messages');
 const {Audit} = require('lighthouse');
@@ -56,6 +57,7 @@ const id = 'ad-render-blocking-resources';
 const {
   title,
   failureTitle,
+  failureDisplayValue,
   description,
 } = AUDITS[id];
 
@@ -106,11 +108,17 @@ class AdRenderBlockingResources extends RenderBlockingResources {
           duration: (record.endTime - record.startTime) * 1000,
         }));
 
-    const pluralEnding = results.length != 1 ? 's' : '';
+    // @ts-ignore
+    const opportunity = Math.max(...tableView.map((r) => r.duration)) / 1000;
+    let displayValue = '';
+    if (results.length > 0 && opportunity > 0) {
+      displayValue = util.format(failureDisplayValue, opportunity.toFixed(2));
+    }
+
     return {
       rawValue: results.length,
       score: results.length ? 0 : 1,
-      displayValue: results.length ? `${results.length} render blocking resource${pluralEnding}` : '',
+      displayValue,
       details: AdRenderBlockingResources.makeTableDetails(HEADINGS, tableView),
     };
   }

--- a/lighthouse-plugin-ad-speed-insights/messages/en-US.json
+++ b/lighthouse-plugin-ad-speed-insights/messages/en-US.json
@@ -10,7 +10,8 @@
     "ad-render-blocking-resources": {
       "title": "Minimal render-blocking resources found",
       "failureTitle": "Avoid render-blocking resources",
-      "description": "Render-blocking resources slow down tag load times. Consider loading critical JS/CSS inline or loading scripts asynchronously. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+      "description": "Render-blocking resources slow down tag load times. Consider loading critical JS/CSS inline or loading scripts asynchronously or loading the tag earlier in the head. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
+      "failureDisplayValue": "Up to %s s tag load time improvement"
     },
     "ad-request-critical-path": {
       "title": "Minimal requests found in ad critical path",


### PR DESCRIPTION
Updates the error message to mention loading the ad tag earlier and display the opportunity for improvement.