### PR TITLE
Fix errors in first ad paint audit

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/messages/en-US.json
+++ b/lighthouse-plugin-ad-speed-insights/messages/en-US.json
@@ -117,6 +117,7 @@
     "DEFAULT": "Audit not applicable",
     "INVALID_TIMING": "Invalid timing task data",
     "NO_AD_RELATED_REQ": "No ad-related requests",
+    "NO_AD_RENDERED": "No ads rendered",
     "NO_ADS_VIEWPORT": "No ads in viewport",
     "NO_ADS": "No ads requested",
     "NO_BIDS": "No bids detected",


### PR DESCRIPTION
Audit had two issues:

- Missing `traces` in required artifacts
- Did not handle cases where iframes existed but did not have contentful paint. As a follow up we should probably check for contentful paint in any child iframes but the audit now falls back to the first paint