### PR TITLE
Add a few safety checks to the iframe gatherer

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/audits/first-ad-paint.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/first-ad-paint.js
@@ -78,7 +78,7 @@ class FirstAdPaint extends Audit {
       return auditNotApplicable(NOT_APPLICABLE.NO_AD_RENDERED);
     }
 
-    const adFrameIds = new Set(slots.map((s) => s.frame.id));
+    const adFrameIds = new Set(slots.map((s) => s.frame && s.frame.id));
 
     const adPaintTime =
         getMinEventTime('firstContentfulPaint', traceEvents, adFrameIds) ||

--- a/lighthouse-plugin-ad-speed-insights/gatherers/iframe-elements.js
+++ b/lighthouse-plugin-ad-speed-insights/gatherers/iframe-elements.js
@@ -109,7 +109,7 @@ class IFrameElements extends Gatherer {
 
     const {frameTree} = await driver.sendCommand('Page.getFrameTree');
     const framesByDomId = new Map();
-    for (const {frame} of frameTree.childFrames) {
+    for (const {frame} of frameTree.childFrames || []) {
       if (framesByDomId.has(frame.name)) {
         // DOM ID collision, mark it as null.
         framesByDomId.set(frame.name, null);

--- a/lighthouse-plugin-ad-speed-insights/typings/artifacts.d.ts
+++ b/lighthouse-plugin-ad-speed-insights/typings/artifacts.d.ts
@@ -22,7 +22,7 @@ declare global {
       clientRect: ClientRect,
       isVisible: boolean,
       isFixed: boolean,
-      frame: LH.Crdp.Page.Frame,
+      frame: (LH.Crdp.Page.Frame|undefined),
     };
     IFrameElements: Array<Artifacts.IFrameElement>;
     StaticAdTags: Array<LH.Crdp.DOM.Node>;


### PR DESCRIPTION
Handles cases where (1) an iframe element doesn't have a matching Frame (possibly due to inability to match when there is a DOM ID collision) and (2) when the main document has no child frames